### PR TITLE
Add option to adjust weekends to closest weekday

### DIFF
--- a/src/payroll-dates.js
+++ b/src/payroll-dates.js
@@ -1,4 +1,12 @@
 var module = function() {
+  var adjustWeekendToClosestWeekday = function(payDate) {
+    if (payDate.getDay() === 0) { // Sunday -> Monday
+      payDate.setDate(payDate.getDate() + 1);
+    } else if (payDate.getDay() === 6) { // Saturday -> Friday
+      payDate.setDate(payDate.getDate() - 1);
+    }
+  };
+
   var PayrollDates = {
     init: function(config) {
       this.config = config;
@@ -59,7 +67,12 @@ var module = function() {
         normalize();
 
         for (var i = 0; i < count; i++) {
-          dates.push(new Date(year, month, datesConfig[dateIndex], 0, 0, 0));
+          var payDate = new Date(year, month, datesConfig[dateIndex], 0, 0, 0);
+          if (this.config.weekendAdjustment === 'closest') {
+            adjustWeekendToClosestWeekday(payDate);
+          }
+
+          dates.push(payDate);
 
           ++dateIndex;
           normalize();

--- a/test/payroll-dates.js
+++ b/test/payroll-dates.js
@@ -119,3 +119,25 @@ test('calculate monthly payroll dates relative to today', function(t) {
     paySchedule.next(4, new Date())
   );
 });
+
+test('calculate monthly payroll dates with weekends adjusted to closest weekday', function(t) {
+  t.plan(1);
+
+  var payrollDates = requirejs('payroll-dates');
+  var paySchedule = payrollDates({
+    repeats: 'monthly',
+    dates: [1, 16],
+    weekendAdjustment: 'closest',
+  });
+
+  t.deepEqual(
+    paySchedule.next(5, '2017-06-29'),
+    [
+      (new Date(2017, 6 - 1, 30)),
+      (new Date(2017, 7 - 1, 17)),
+      (new Date(2017, 8 - 1, 1)),
+      (new Date(2017, 8 - 1, 16)),
+      (new Date(2017, 9 - 1, 1)),
+    ]
+  );
+});


### PR DESCRIPTION
Monthly payroll dates will sometimes fall on weekends.  These payroll
dates are sometimes instead effective on the closest weekday, so this
option allows for the payroll dates calculator to be configured to make
this adjustment.