### PR TITLE
Add the ability to shift weekend to next or previous weekday

### DIFF
--- a/src/payroll-dates.js
+++ b/src/payroll-dates.js
@@ -1,34 +1,20 @@
 var module = function() {
   var adjustDate = function(payDate) {
     if (this.config.weekendAdjustment === 'closest') {
-      return adjustWeekendToClosestWeekday(payDate);
+      return adjustWeekend(payDate, -1, 1);
     }
     if (this.config.weekendAdjustment === 'previous') {
-      return adjustWeekendToPreviousWeekday(payDate);
+      return adjustWeekend(payDate, -1, -2);
     }
     if (this.config.weekendAdjustment === 'next') {
-      return adjustWeekendToNextWeekday(payDate);
+      return adjustWeekend(payDate, 2, 1);
     }
   };
-  var adjustWeekendToClosestWeekday = function(payDate) {
-    if (payDate.getDay() === 0) { // Sunday -> Monday
-      payDate.setDate(payDate.getDate() + 1);
-    } else if (payDate.getDay() === 6) { // Saturday -> Friday
-      payDate.setDate(payDate.getDate() - 1);
-    }
-  };
-  var adjustWeekendToPreviousWeekday = function(payDate) {
-    if (payDate.getDay() === 0) { // Sunday -> Friday
-      payDate.setDate(payDate.getDate() - 2);
-    } else if (payDate.getDay() === 6) { // Saturday -> Friday
-      payDate.setDate(payDate.getDate() - 1);
-    }
-  };
-  var adjustWeekendToNextWeekday = function(payDate) {
-    if (payDate.getDay() === 0) { // Sunday -> Monday
-      payDate.setDate(payDate.getDate() + 1);
-    } else if (payDate.getDay() === 6) { // Saturday -> Monday
-      payDate.setDate(payDate.getDate() + 2);
+  var adjustWeekend = function(payDate, saturdayAdjustment, sundayAdjustment) {
+    if (payDate.getDay() === 0) {
+      payDate.setDate(payDate.getDate() + sundayAdjustment);
+    } else if (payDate.getDay() === 6) {
+      payDate.setDate(payDate.getDate() + saturdayAdjustment);
     }
   };
 

--- a/src/payroll-dates.js
+++ b/src/payroll-dates.js
@@ -1,9 +1,34 @@
 var module = function() {
+  var adjustDate = function(payDate) {
+    if (this.config.weekendAdjustment === 'closest') {
+      return adjustWeekendToClosestWeekday(payDate);
+    }
+    if (this.config.weekendAdjustment === 'previous') {
+      return adjustWeekendToPreviousWeekday(payDate);
+    }
+    if (this.config.weekendAdjustment === 'next') {
+      return adjustWeekendToNextWeekday(payDate);
+    }
+  };
   var adjustWeekendToClosestWeekday = function(payDate) {
     if (payDate.getDay() === 0) { // Sunday -> Monday
       payDate.setDate(payDate.getDate() + 1);
     } else if (payDate.getDay() === 6) { // Saturday -> Friday
       payDate.setDate(payDate.getDate() - 1);
+    }
+  };
+  var adjustWeekendToPreviousWeekday = function(payDate) {
+    if (payDate.getDay() === 0) { // Sunday -> Friday
+      payDate.setDate(payDate.getDate() - 2);
+    } else if (payDate.getDay() === 6) { // Saturday -> Friday
+      payDate.setDate(payDate.getDate() - 1);
+    }
+  };
+  var adjustWeekendToNextWeekday = function(payDate) {
+    if (payDate.getDay() === 0) { // Sunday -> Monday
+      payDate.setDate(payDate.getDate() + 1);
+    } else if (payDate.getDay() === 6) { // Saturday -> Monday
+      payDate.setDate(payDate.getDate() + 2);
     }
   };
 
@@ -68,9 +93,7 @@ var module = function() {
 
         for (var i = 0; i < count; i++) {
           var payDate = new Date(year, month, datesConfig[dateIndex], 0, 0, 0);
-          if (this.config.weekendAdjustment === 'closest') {
-            adjustWeekendToClosestWeekday(payDate);
-          }
+          adjustDate.call(this, payDate);
 
           dates.push(payDate);
 

--- a/test/payroll-dates.js
+++ b/test/payroll-dates.js
@@ -141,3 +141,47 @@ test('calculate monthly payroll dates with weekends adjusted to closest weekday'
     ]
   );
 });
+
+test('calculate monthly payroll dates with weekends adjusted to previous weekday', function(t) {
+  t.plan(1);
+
+  var payrollDates = requirejs('payroll-dates');
+  var paySchedule = payrollDates({
+    repeats: 'monthly',
+    dates: [1, 16],
+    weekendAdjustment: 'previous',
+  });
+
+  t.deepEqual(
+    paySchedule.next(5, '2017-06-29'),
+    [
+      (new Date(2017, 6 - 1, 30)),
+      (new Date(2017, 7 - 1, 14)),
+      (new Date(2017, 8 - 1, 1)),
+      (new Date(2017, 8 - 1, 16)),
+      (new Date(2017, 9 - 1, 1)),
+    ]
+  );
+});
+
+test('calculate monthly payroll dates with weekends adjusted to next weekday', function(t) {
+  t.plan(1);
+
+  var payrollDates = requirejs('payroll-dates');
+  var paySchedule = payrollDates({
+    repeats: 'monthly',
+    dates: [1, 16],
+    weekendAdjustment: 'next',
+  });
+
+  t.deepEqual(
+    paySchedule.next(5, '2017-06-29'),
+    [
+      (new Date(2017, 7 - 1, 3)),
+      (new Date(2017, 7 - 1, 17)),
+      (new Date(2017, 8 - 1, 1)),
+      (new Date(2017, 8 - 1, 16)),
+      (new Date(2017, 9 - 1, 1)),
+    ]
+  );
+});


### PR DESCRIPTION
Shifting to the closest day makes sense in some cases, but some
businesses prefer to always pay always before or always after the normal
pay day if the day falls on a weekend.